### PR TITLE
Expand tests and documentation coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,340 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "gossip-p2p"
 version = "0.1.0"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.5+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ name = "gossip_p2p"
 path = "src/main.rs"
 
 [dependencies]
+
+[dev-dependencies]
+proptest = "1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,4 +181,11 @@ mod tests {
         let args = vec!["--period=5".to_string()];
         assert!(parse_arguments(&args).is_err());
     }
+
+    #[test]
+    fn help_message_contains_usage() {
+        let msg = get_help_message("prog");
+        assert!(msg.contains("Usage:"));
+        assert!(msg.contains("--period"));
+    }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -102,25 +102,47 @@ impl Message {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
-    fn serialize_roundtrip() {
-        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
-        let messages = vec![
-            Message::Join(addr),
-            Message::Peers(vec![addr]),
-            Message::Text("hi".to_string()),
-        ];
-        for msg in messages {
-            let line = msg.serialize();
-            let parsed = Message::parse(&line).unwrap();
-            assert_eq!(msg, parsed);
-        }
+    fn parse_invalid_format() {
+        let err = Message::parse("UNKNOWN").unwrap_err();
+        assert!(matches!(err, MessageError::InvalidFormat));
     }
 
     #[test]
-    fn parse_invalid() {
-        let err = Message::parse("UNKNOWN").unwrap_err();
-        matches!(err, MessageError::InvalidFormat);
+    fn parse_invalid_address() {
+        let err = Message::parse("JOIN not-an-addr").unwrap_err();
+        assert!(matches!(err, MessageError::InvalidAddress(_)));
+    }
+
+    fn ipv4_addr() -> impl Strategy<Value = SocketAddr> {
+        (any::<[u8; 4]>(), any::<u16>()).prop_map(|(ip, port)| SocketAddr::from((ip, port)))
+    }
+
+    proptest! {
+        #[test]
+        fn join_roundtrip(addr in ipv4_addr()) {
+            let msg = Message::Join(addr);
+            let line = msg.serialize();
+            let parsed = Message::parse(&line).unwrap();
+            prop_assert_eq!(parsed, msg);
+        }
+
+        #[test]
+        fn text_roundtrip(text in proptest::string::string_regex("[A-Za-z0-9]{0,64}").unwrap()) {
+            let msg = Message::Text(text.clone());
+            let line = msg.serialize();
+            let parsed = Message::parse(&line).unwrap();
+            prop_assert_eq!(parsed, msg);
+        }
+
+        #[test]
+        fn peers_roundtrip(addrs in proptest::collection::vec(ipv4_addr(), 0..8)) {
+            let msg = Message::Peers(addrs.clone());
+            let line = msg.serialize();
+            let parsed = Message::parse(&line).unwrap();
+            prop_assert_eq!(parsed, msg);
+        }
     }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -11,7 +11,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// A simple printer for logging events with time elapsed since an `Instant`.
 pub struct SimplePrinter;
@@ -30,21 +30,38 @@ impl SimplePrinter {
     /// Basic usage:
     ///
     /// ```
-    /// let start_time = std::time::Instant::now();
-    /// let start_time = std::sync::Arc::new(start_time);
-    /// simple_printer::SimplePrinter::time(start_time, "Hello, world!");
+    /// use std::sync::Arc;
+    /// use std::time::Instant;
+    ///
+    /// let start_time = Arc::new(Instant::now());
+    /// gossip_p2p::printer::SimplePrinter::time(start_time, "Hello, world!");
     /// ```
     fn time(start_time: Arc<Instant>, msg: &str) {
         let elapsed = Instant::now().duration_since(*start_time);
-
-        // Calculate hours, minutes, and seconds from elapsed time
-        let hours = elapsed.as_secs() / 3600;
-        let minutes = (elapsed.as_secs() % 3600) / 60;
-        let seconds = elapsed.as_secs() % 60;
-
-        // Print the formatted message with elapsed time
-        println!("# {:02}:{:02}:{:02} - {}", hours, minutes, seconds, msg);
+        println!("{}", format_elapsed(elapsed, msg));
     }
+}
+
+/// Format a message with the elapsed time.
+///
+/// This helper returns the formatted output used by [`SimplePrinter`].
+///
+/// # Examples
+///
+/// ```
+/// use gossip_p2p::printer::format_elapsed;
+/// use std::time::Duration;
+///
+/// assert_eq!(
+///     format_elapsed(Duration::new(3661, 0), "hi"),
+///     "# 01:01:01 - hi"
+/// );
+/// ```
+pub fn format_elapsed(elapsed: Duration, msg: &str) -> String {
+    let hours = elapsed.as_secs() / 3600;
+    let minutes = (elapsed.as_secs() % 3600) / 60;
+    let seconds = elapsed.as_secs() % 60;
+    format!("# {:02}:{:02}:{:02} - {}", hours, minutes, seconds, msg)
 }
 
 /// Initializes the printing utility and logs the starting event.
@@ -67,7 +84,7 @@ impl SimplePrinter {
 ///
 /// ```
 /// let addr = "127.0.0.1:8080".parse().unwrap();
-/// let start_time = simple_printer::init(&addr);
+/// let start_time = gossip_p2p::printer::init(&addr);
 /// ```
 pub fn init(addr: &SocketAddr) -> Arc<Instant> {
     let start_time = Arc::new(Instant::now());
@@ -96,8 +113,26 @@ pub fn init(addr: &SocketAddr) -> Arc<Instant> {
 ///
 /// ```
 /// // Assuming `start_time` has been initialized using `init` function
-/// simple_printer::print_event(start_time, "Event occurred");
+/// gossip_p2p::printer::print_event(start_time, "Event occurred");
 /// ```
 pub fn print_event(start_time: Arc<Instant>, msg: &str) {
     SimplePrinter::time(start_time, msg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_elapsed_formats() {
+        let formatted = format_elapsed(Duration::new(3661, 0), "test");
+        assert_eq!(formatted, "# 01:01:01 - test");
+    }
+
+    #[test]
+    fn init_sets_start_time() {
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let start = init(&addr);
+        assert!(Instant::now().duration_since(*start) < Duration::from_secs(1));
+    }
 }


### PR DESCRIPTION
## Summary
- add property-based tests for message serialization and parsing
- introduce `format_elapsed` utility with tests for the printer module
- cover CLI help output with dedicated test

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68c685561b4c832bbe4c5bc6c06f91f3